### PR TITLE
Load jumpscare animation frames earlier.

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1103,6 +1103,14 @@ class PlayState extends MusicBeatState
 					FlxTween.tween(blackFuck, {alpha: 0}, 1);
 				});
 
+				if (FlxG.save.data.jumpscares) {
+					// Preload the main jumpscare, if we're going to use it.
+					// This increases memory usage but removes the lag spike.
+					// Disabling jumpscares in the options will reduce the memory usage.
+					daJumpscare.frames = Paths.getSparrowAtlas('sonicJUMPSCARE', 'exe');
+					daJumpscare.animation.addByPrefix('jump','sonicSPOOK',24, false);
+				}
+
 				default:
 					startCountdown();
 			}
@@ -1307,12 +1315,7 @@ class PlayState extends MusicBeatState
 	function doJumpscare()
 		{
 			trace ('JUMPSCARE aaaa');
-			
-			
-	
-			daJumpscare.frames = Paths.getSparrowAtlas('sonicJUMPSCARE', 'exe');
-			daJumpscare.animation.addByPrefix('jump','sonicSPOOK',24, false);
-			
+
 			daJumpscare.screenCenter();
 
 			daJumpscare.scale.x = 1.1;


### PR DESCRIPTION
I was annoyed by the severe lag spike that occurs just before the main jumpscare (and which appears in EVERY YouTube video showcasing the mod), to the point where I decided to try to resolve it myself.

I believe the lag occurs because, despite all the files in the `assets/exe` folder being loaded into the Bitmap cache, the process of loading it into the FlxAtlasFrames object requires an expensive operation of parsing the XML file, splitting the spritesheet, loading the individual frames into memory, and preparing them to be accessed by the FlxSprite.

We can see proof that this is the case through this change. By moving the initialization of the sprite from the `doJumpscare` method to the `create` method alongside the stage initialization, the frame rate dip is drastically reduced.

This pre-loading process is only done when jumpscares are enabled. in order to save memory.

As an addendum, I was concerned about the memory impact of this change, so I profiled the game's memory usage at the beginning of the song as well as just after the primary jumpscare to preview the performance changes.

The base code, without the fix, at the start of the song:
![SonicExe-NoFix-PreScare](https://user-images.githubusercontent.com/4635334/130709273-d4c787a5-041b-4c8b-996f-48f3ee6d5c3f.png)
The base code, without the fix, after the jumpscare:
![SonicExe-NoFix-PostScare](https://user-images.githubusercontent.com/4635334/130709279-b3f0d3e0-ffc1-43be-aa86-34b1c5ff16b2.png)

I have two takeaways from this:
* The jumpscare alone takes up about 250 mb of memory once loaded. The spritesheet itself takes 6mb, I wonder if there's some optimization that can be performed that will reduce this.
* The lag spike is ABSURD. You can see the frame rate drop to nearly 0 FPS, which indicates that attempting to load the jumpscare mid-song freezes the game for nearly a second. Ouch.

Here are the results from after the fix.
Beginning of the song:
![SonicExe-Fix-PreScare](https://user-images.githubusercontent.com/4635334/130709723-b554b24d-840b-4e26-a49b-e95c9df8fcc9.png)
After the jumpscare:
![SonicExe-Fix-PostScare](https://user-images.githubusercontent.com/4635334/130709736-880003b7-095e-4b05-84c5-02b76990d395.png)

From this, it appears that the change does a couple of things:
1. It moves the lagspike to the beginning of the song. This has minimal impact on the user since this occurs before the song title appears, when the screen is fully black.
2. The jumpscare has a drastically reduced frame rate impact, which makes for a vastly improved user experience.
3. The memory usage is increased at the beginning of the song, but it merely makes the memory usage the same at the beginning of the song as it is at the end. Again, any users experiencing performance issues can disable the graphics from the options menu and the jumpscare will not be preloaded.

Overall, I believe that this change is a drastic improvement and hope it can be implemented in a future release.